### PR TITLE
fix fastcgi_buffer_size typo in nginx.conf

### DIFF
--- a/install/etc/nginx/nginx.conf
+++ b/install/etc/nginx/nginx.conf
@@ -37,7 +37,7 @@ http {
     client_max_body_size <UPLOAD_MAX_SIZE>;
 
     fastcgi_buffers <FASTCGI_BUFFERS>;
-    fastcgi_buffer_suze <FASTCGI_BUFFER_SIZE>;
+    fastcgi_buffer_size <FASTCGI_BUFFER_SIZE>;
 
     server_tokens off;
     include /etc/nginx/nginx.conf.d/reverse_proxy.conf;


### PR DESCRIPTION
latest _self-service-password_ image fails to start as there is a little typo here in _nginx.conf_.
this PR fixes it - `fastcgi_buffer_suze` => `fastcgi_buffer_size`.